### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,9 @@
+container:
+  image: node:latest
+
+test_task:
+  node_modules_cache:
+    folder: node_modules
+    fingerprint_script: cat package-lock.json
+    populate_script: npm install
+  test_script: npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm](https://img.shields.io/npm/v/tink.svg)](https://npm.im/tink) [![license](https://img.shields.io/npm/l/tink.svg)](https://npm.im/tink) [![Travis](https://img.shields.io/travis/npm/tink.svg)](https://travis-ci.org/npm/tink) [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/npm/tink?svg=true)](https://ci.appveyor.com/project/npm/tink) [![Coverage Status](https://coveralls.io/repos/github/npm/tink/badge.svg?branch=latest)](https://coveralls.io/github/npm/tink?branch=latest)
+[![npm](https://img.shields.io/npm/v/tink.svg)](https://npm.im/tink) [![license](https://img.shields.io/npm/l/tink.svg)](https://npm.im/tink) [![Build Status](https://api.cirrus-ci.com/github/npm/tink.svg)](https://cirrus-ci.com/github/npm/tink)
 
 [`tink`](https://github.com/npm/tink) is an experimental package manager for
 JavaScript. Don't expect to be able to use this with any of your existing


### PR DESCRIPTION
EDIT: there is no CI configured at the moment. This change proposes to add Cirrus CI which allows to use official Docker images.

Configure [Cirrus CI](https://github.com/marketplace/cirrus-ci/) based on the latest official Docker image of Node.js.

![image](https://user-images.githubusercontent.com/989066/45508580-2ed29c80-b763-11e8-92db-0cf57572d80a.png)

If you choose to merge don't forget to install [Cirrus CI from GitHub Marketplace](https://github.com/marketplace/cirrus-ci/) first.



