### PR TITLE
Fix "tinkged-package" typo after the second great rename

### DIFF
--- a/lib/ensure-package.js
+++ b/lib/ensure-package.js
@@ -224,7 +224,7 @@ async function ensurePackage (name, dep, opts) {
     if (!integrity) { integrity = mani._integrity }
   }
   if (integrity) {
-    const info = await cacache.get.info(opts.cache, `tinkged-package:${INDEX_VERSION}:${integrity}`)
+    const info = await cacache.get.info(opts.cache, `tinked-package:${INDEX_VERSION}:${integrity}`)
     if (info) {
       return JSON.parse(info.metadata)
     }


### PR DESCRIPTION
I believe that `tinkged-package` is a mistake made during the second great rename. It says `tinked-package` (without the g) a couple of lines below.

https://github.com/npm/tink/blob/56a15f5b50a66f6dba72d72d29adbfd73c436619/lib/ensure-package.js#L255


P.S. I read the CONTRIBUTING.md and it says to file an issue at https://github.com/npm/tink/issues.
The Issue feature has been deactivated on your GitHub repo, so here is just a PR.