### PR TITLE
fix: check path.toNamespacedPath before call

### DIFF
--- a/lib/pkgmap.js
+++ b/lib/pkgmap.js
@@ -32,7 +32,7 @@ function resolve (...p) {
     pkgMap = pkgMapCache.get(pkgMapPath)
   } else {
     try {
-      const p = path.toNamespacedPath(pkgMapPath)
+      const p = path.toNamespacedPath ? path.toNamespacedPath(pkgMapPath) : pkgMapPath
       pkgMap = JSON.parse(fs.readFileSync(p))
       pkgMapCache.set(pkgMapPath, pkgMap)
     } catch (err) {


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
`path.toNamespacedPath` was added in `Node v9.0.0`. Check before call the method or let people hnow that they should update their `Node` version.