### PR TITLE
deps: ini as plain dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2422,8 +2422,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "get-stream": "^4.1.0",
     "glob": "^7.1.3",
     "graceful-fs": "^4.1.11",
+    "ini": "^1.3.5",
     "jsx-transform": "^2.4.0",
     "libnpm": "^1.0.0",
     "lock-verify": "^2.0.2",


### PR DESCRIPTION
Fixes `Cannot find module 'ini'` when running tink installed with npm.