### PR TITLE
feat(access): add `tink access` subcommands

### DIFF
--- a/bin/tink.js
+++ b/bin/tink.js
@@ -7,7 +7,7 @@ const CMDS = new Map([
   ['rm', require('../lib/commands/rm.js')],
   ['shell', require('../lib/commands/shell.js')],
   ['org', require('../lib/commands/org.jsx')],
-  ['access', require('../lib/commands/access.js')],
+  ['access', require('../lib/commands/access.jsx')],
   ['prepare', require('../lib/commands/prepare.js')],
   ['ping', require('../lib/commands/ping.js')],
   ['deprecate', require('../lib/commands/deprecate.js')],

--- a/bin/tink.js
+++ b/bin/tink.js
@@ -7,6 +7,7 @@ const CMDS = new Map([
   ['rm', require('../lib/commands/rm.js')],
   ['shell', require('../lib/commands/shell.js')],
   ['org', require('../lib/commands/org.jsx')],
+  ['access', require('../lib/commands/access.js')],
   ['prepare', require('../lib/commands/prepare.js')],
   ['ping', require('../lib/commands/ping.js')],
   ['deprecate', require('../lib/commands/deprecate.js')],

--- a/bin/tink.js
+++ b/bin/tink.js
@@ -3,14 +3,14 @@
 require('../lib/node/index.js')
 
 const CMDS = new Map([
+  ['access', require('../lib/commands/access.jsx')],
   ['add', require('../lib/commands/add.js')],
+  ['deprecate', require('../lib/commands/deprecate.js')],
+  ['org', require('../lib/commands/org.jsx')],
+  ['ping', require('../lib/commands/ping.js')],
+  ['prepare', require('../lib/commands/prepare.js')],
   ['rm', require('../lib/commands/rm.js')],
   ['shell', require('../lib/commands/shell.js')],
-  ['org', require('../lib/commands/org.jsx')],
-  ['access', require('../lib/commands/access.jsx')],
-  ['prepare', require('../lib/commands/prepare.js')],
-  ['ping', require('../lib/commands/ping.js')],
-  ['deprecate', require('../lib/commands/deprecate.js')],
   ['view', require('../lib/commands/view.js')]
 ])
 

--- a/lib/commands/access.js
+++ b/lib/commands/access.js
@@ -53,9 +53,9 @@ const Access = module.exports = {
       .command(
         'edit [<package>]',
         'Show all of the access privileges for a package. Will only show ' +
-        'permissions for packages to which you have at least read access. ' +
-        'If <user> is passed in, the list is filtered only to teams that ' +
-        'user happens to belong to',
+          'permissions for packages to which you have at least read access. ' +
+          'If <user> is passed in, the list is filtered only to teams that ' +
+          'user happens to belong to',
         Access.options,
         async argv => accessEdit(argv)
       )

--- a/lib/commands/access.js
+++ b/lib/commands/access.js
@@ -1,0 +1,92 @@
+'use strict'
+
+const Access = module.exports = {
+  command: 'access',
+  describe: 'access-related subcommands',
+  builder (y) {
+    return y.help().alias('help', 'h')
+      .options(Access.options)
+      .demandCommand(1, 'Access subcommand is required')
+      .recommendCommands()
+      .command(
+        'public [<package>]',
+        'Set a package to be publicly accessible',
+        Access.options,
+        async argv => accessPublic(argv)
+      )
+      .command(
+        'restricted [<package>]',
+        'Set a package to be restricted',
+        Access.options,
+        async argv => accessRestricted(argv)
+      )
+      .command(
+        'grant <read-only|read-write> <scope:team> [<package>]',
+        'Add the ability of users and teams to have read-only or ' +
+          'read-write access to a package',
+        Access.options,
+        async argv => accessGrant(argv)
+      )
+      .command(
+        'revoke <scope:team> [<package>]',
+        'Remove the ability of users and teams to have read-only or ' +
+          'read-write access to a package',
+        Access.options,
+        async argv => accessRevoke(argv)
+      )
+      .command(
+        'ls-packages [<user>|<scope>|<scope:team>]',
+        'Show all of the packages a user or a team is able to access, along ' +
+          'with the access level, except for read-only public packages',
+        Access.options,
+        async argv => accessLsPackages(argv)
+      )
+      .command(
+        'ls-collaborators [<package> [<user>]]',
+        'Show all of the access privileges for a package. Will only show ' +
+          'permissions for packages to which you have at least read access. ' +
+          'If <user> is passed in, the list is filtered only to teams that ' +
+          'user happens to belong to',
+        Access.options,
+        async argv => accessLsCollaborators(argv)
+      )
+      .command(
+        'edit [<package>]',
+        'Show all of the access privileges for a package. Will only show ' +
+        'permissions for packages to which you have at least read access. ' +
+        'If <user> is passed in, the list is filtered only to teams that ' +
+        'user happens to belong to',
+        Access.options,
+        async argv => accessEdit(argv)
+      )
+  },
+  options: Object.assign(require('../common-opts.js', {}))
+}
+
+async function accessPublic (argv) {
+  // TODO: stub
+}
+
+async function accessRestricted (argv) {
+  // TODO: stub
+}
+
+async function accessGrant (argv) {
+  // TODO: stub
+}
+
+async function accessRevoke (argv) {
+  // TODO: stub
+}
+
+async function accessLsPackages (argv) {
+  // TODO: stub
+}
+
+async function accessLsCollaborators (argv) {
+  // TODO: stub
+}
+
+async function accessEdit (argv) {
+  // TODO: stub
+}

--- a/lib/commands/access.jsx
+++ b/lib/commands/access.jsx
@@ -135,22 +135,21 @@ async function accessLsCollaborators (argv) {
       await libnpm.access.lsCollaborators(argv.spec, argv.user, opts)
     render(opts, collaborators)
   } else {
-    findPrefix(process.cwd())
-      .then(prefix => {
-        readJson(
-          `${prefix}/package.json`,
-          console.error,
-          false,
-          async (er, data) => {
-            if (er) {
-              console.error('There was an error reading the file')
-            }
-            const collaborators =
-              await libnpm.access.lsCollaborators(data.name, argv.user, opts)
-            render(opts, collaborators)
+    findPrefix(process.cwd()).then(prefix => {
+      readJson(
+        `${prefix}/package.json`,
+        console.error,
+        false,
+        async (er, data) => {
+          if (er) {
+            console.error('There was an error reading the file')
           }
-        )
-      })
+          const collaborators =
+            await libnpm.access.lsCollaborators(data.name, argv.user, opts)
+          render(opts, collaborators)
+        }
+      )
+    })
   }
 }
 

--- a/lib/commands/access.jsx
+++ b/lib/commands/access.jsx
@@ -85,7 +85,7 @@ async function accessLsPackages (argv) {
 
 async function accessLsCollaborators (argv) {
   const figgyPudding = require('figgy-pudding')
-  const { renderToString } = require('ink')
+  const { h, renderToString } = require('ink')
   const libnpm = require('libnpm')
   const npmConfig = require('../config.js')
   const Table = require('ink-table').default

--- a/lib/commands/access.jsx
+++ b/lib/commands/access.jsx
@@ -52,10 +52,7 @@ const Access = module.exports = {
       )
       .command(
         'edit [<package>]',
-        'Show all of the access privileges for a package. Will only show ' +
-          'permissions for packages to which you have at least read access. ' +
-          'If <user> is passed in, the list is filtered only to teams that ' +
-          'user happens to belong to',
+        'Set the access privileges for a package at once using $EDITOR',
         Access.options,
         async argv => accessEdit(argv)
       )

--- a/lib/commands/access.jsx
+++ b/lib/commands/access.jsx
@@ -51,7 +51,7 @@ const Access = module.exports = {
         async argv => accessLsCollaborators(argv)
       )
       .command(
-        'edit [<package>]',
+        'edit <package>',
         'Set the access privileges for a package at once using $EDITOR',
         Access.options,
         async argv => accessEdit(argv)

--- a/lib/commands/access.jsx
+++ b/lib/commands/access.jsx
@@ -96,18 +96,22 @@ const render = (opts, content) => {
 
 async function accessPublic (argv) {
   await libnpm.access.public(argv.spec, parseOpts(argv))
+    .catch(e => console.error(e))
 }
 
 async function accessRestricted (argv) {
   await libnpm.access.restricted(argv.spec, parseOpts(argv))
+    .catch(e => console.error(e))
 }
 
 async function accessGrant (argv) {
   await access.grant(argv.spec, argv.team, argv.permissions, parseOpts(argv))
+    .catch(e => console.error(e))
 }
 
 async function accessRevoke (argv) {
   await libnpm.access.revoke(argv.spec, argv.team, parseOpts(argv))
+    .catch(e => console.error(e))
 }
 
 async function accessLsPackages (argv) {
@@ -121,7 +125,9 @@ async function accessLsPackages (argv) {
 
   const opts = parseOpts(argv)
   // TODO: error when opts is used as 2nd param in .lsPackages
-  const packages = await libnpm.access.lsPackages(entity)
+  const packages =
+    await libnpm.access.lsPackages(entity)
+      .catch(e => console.error(e))
   render(opts, packages)
 }
 
@@ -133,6 +139,7 @@ async function accessLsCollaborators (argv) {
   if (argv.spec) {
     const collaborators =
       await libnpm.access.lsCollaborators(argv.spec, argv.user, opts)
+        .catch(e => console.error(e))
     render(opts, collaborators)
   } else {
     findPrefix(process.cwd()).then(prefix => {
@@ -146,6 +153,7 @@ async function accessLsCollaborators (argv) {
           }
           const collaborators =
             await libnpm.access.lsCollaborators(data.name, argv.user, opts)
+              .catch(e => console.error(e))
           render(opts, collaborators)
         }
       )

--- a/lib/commands/access.jsx
+++ b/lib/commands/access.jsx
@@ -9,40 +9,40 @@ const Access = module.exports = {
       .demandCommand(1, 'Access subcommand is required')
       .recommendCommands()
       .command(
-        'public [<package>]',
+        'public <spec>',
         'Set a package to be publicly accessible',
         Access.options,
         async argv => accessPublic(argv)
       )
       .command(
-        'restricted [<package>]',
+        'restricted <spec>',
         'Set a package to be restricted',
         Access.options,
         async argv => accessRestricted(argv)
       )
       .command(
-        'grant <read-only|read-write> <scope:team> [<package>]',
+        'grant <permissions> <team> <spec>',
         'Add the ability of users and teams to have read-only or ' +
           'read-write access to a package',
         Access.options,
         async argv => accessGrant(argv)
       )
       .command(
-        'revoke <scope:team> [<package>]',
+        'revoke <team> <spec>',
         'Remove the ability of users and teams to have read-only or ' +
           'read-write access to a package',
         Access.options,
         async argv => accessRevoke(argv)
       )
       .command(
-        'ls-packages <entity>',
+        'ls-packages [<entity>]',
         'Show all of the packages a user or a team is able to access, along ' +
           'with the access level, except for read-only public packages',
         Access.options,
         async argv => accessLsPackages(argv)
       )
       .command(
-        'ls-collaborators [<package> [<user>]]',
+        'ls-collaborators [<spec> [<user>]]',
         'Show all of the access privileges for a package. Will only show ' +
           'permissions for packages to which you have at least read access. ' +
           'If <user> is passed in, the list is filtered only to teams that ' +
@@ -95,52 +95,45 @@ const render = (opts, content) => {
 }
 
 async function accessPublic (argv) {
-  // TODO: stub
+  await libnpm.access.public(argv.spec, parseOpts(argv))
 }
 
 async function accessRestricted (argv) {
-  // TODO: stub
+  await libnpm.access.restricted(argv.spec, parseOpts(argv))
 }
 
 async function accessGrant (argv) {
-  // TODO: stub
+  await access.grant(argv.spec, argv.team, argv.permissions, parseOpts(argv))
 }
 
 async function accessRevoke (argv) {
-  // TODO: stub
+  await libnpm.access.revoke(argv.spec, argv.team, parseOpts(argv))
 }
 
 async function accessLsPackages (argv) {
-  const opts = parseOpts(argv)
   const getPackagesByCurrentUser = () => {
-    // TODO: grab current authenticated user
-    // TODO: seems to need whoami support
-    return null
+    // TODO: grab current authenticated user from pending whoami support
   }
 
   const entity = argv.entity
     ? argv.entity
     : getPackagesByCurrentUser()
 
-    const packages = await libnpm.access.lsPackages(entity)
-    render(opts, packages)
+  const opts = parseOpts(argv)
+  // TODO: error when opts is used as 2nd param in .lsPackages
+  const packages = await libnpm.access.lsPackages(entity)
+  render(opts, packages)
 }
 
 async function accessLsCollaborators (argv) {
-  const npa = require("npm-package-arg")
   const findPrefix = require('find-npm-prefix')
   const readJson = require('read-package-json')
   const opts = parseOpts(argv)
 
-  if (argv.package) {
-    try {
-      const packageName = npa(argv.package)
-      const collaborators =
-        await libnpm.access.lsCollaborators(packageName, argv.user, opts)
-      render(opts, collaborators)
-    } catch (err) {
-      console.error(err)
-    }
+  if (argv.spec) {
+    const collaborators =
+      await libnpm.access.lsCollaborators(argv.spec, argv.user, opts)
+    render(opts, collaborators)
   } else {
     findPrefix(process.cwd())
       .then(prefix => {


### PR DESCRIPTION
- [x] `tink access` subcommand subs

###### Subcommand Checklist
- [x] `public`
- [x] `restricted`
- [x] `grant`
- [x] `revoke`
- [x] `ls-packages`
- [x] `ls-collaborators` (w. `// TODO: grab current authenticated user from pending whoami support`)
- ~[ ] `edit`~ (confirmed in [review comment](https://github.com/npm/tink/pull/12#issuecomment-437952581) that `edit` is out of scope.