### PR TITLE
feat(commands): add 'deprecate' command

### DIFF
--- a/bin/tink.js
+++ b/bin/tink.js
@@ -6,7 +6,8 @@ const CMDS = new Map([
   ['shell', require('../lib/commands/shell.js')],
   ['org', require('../lib/commands/org.jsx')],
   ['prepare', require('../lib/commands/prepare.js')],
-  ['ping', require('../lib/commands/ping.js')]
+  ['ping', require('../lib/commands/ping.js')],
+  ['deprecate', require('../lib/commands/deprecate.js')]
 ])
 
 if (require.main === module) {

--- a/lib/commands/deprecate.js
+++ b/lib/commands/deprecate.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const Deprecate = module.exports = {
+  command: 'deprecate <pkg>[@<version>] <message>',
+  describe: 'Deprecate a version of a package',
+  builder (y) {
+    return y.help().alias('help', 'h')
+      .options(Deprecate.options)
+  },
+  options: Object.assign(require('../common-opts.js', {})),
+  handler: async argv => deprecate(argv)
+}
+
+async function deprecate (argv) {
+  const figgyPudding = require('figgy-pudding')
+  const BB = require('bluebird')
+  const libnpm = require('libnpm')
+  const npmConfig = require('../config.js')
+  const semver = require('semver')
+  // const otplease = require('./utils/otplease.js')
+
+  const DeprecateConfig = figgyPudding({
+    json: {},
+    loglevel: {},
+    parseable: {},
+    silent: {}
+  })
+
+  const opts = DeprecateConfig(npmConfig().concat(argv).concat({
+    log: require('npmlog')
+  }))
+
+  return BB.try(() => {
+    // fetch the data and make sure it exists.
+    const p = libnpm.parseArg(argv['pkg@version'])
+
+    // npa makes the default spec "latest", but for deprecation
+    // "*" is the appropriate default.
+    const spec = p.rawSpec === '' ? '*' : p.fetchSpec
+
+    if (semver.validRange(spec, true) === null) {
+      throw new Error('invalid version range: ' + spec)
+    }
+
+    const uri = '/' + p.escapedName
+    return libnpm.fetch.json(uri, opts.concat({
+      spec: p,
+      query: {write: true}
+    })).then(packument => {
+      // filter all the versions that match
+      Object.keys(packument.versions)
+        .filter(v => semver.satisfies(v, spec))
+        .forEach(v => { packument.versions[v].deprecated = argv.message })
+      // TODO: re-add otplease
+      return libnpm.fetch(uri, opts.concat({
+        spec: p,
+        method: 'PUT',
+        body: packument,
+        ignoreBody: true
+      }))
+    })
+  })
+}
+

--- a/lib/commands/deprecate.js
+++ b/lib/commands/deprecate.js
@@ -17,7 +17,7 @@ async function deprecate (argv) {
   const libnpm = require('libnpm')
   const npmConfig = require('../config.js')
   const semver = require('semver')
-  // const otplease = require('./utils/otplease.js')
+  const otplease = require('../utils/otplease.js')
 
   const DeprecateConfig = figgyPudding({
     json: {},
@@ -51,14 +51,12 @@ async function deprecate (argv) {
       Object.keys(packument.versions)
         .filter(v => semver.satisfies(v, spec))
         .forEach(v => { packument.versions[v].deprecated = argv.message })
-      // TODO: re-add otplease
-      return libnpm.fetch(uri, opts.concat({
+      return otplease(opts, opts => libnpm.fetch(uri, opts.concat({
         spec: p,
         method: 'PUT',
         body: packument,
         ignoreBody: true
-      }))
+      })))
     })
   })
 }
-

--- a/lib/commands/deprecate.js
+++ b/lib/commands/deprecate.js
@@ -45,7 +45,7 @@ async function deprecate (argv) {
     const uri = '/' + p.escapedName
     return libnpm.fetch.json(uri, opts.concat({
       spec: p,
-      query: {write: true}
+      query: { write: true }
     })).then(packument => {
       // filter all the versions that match
       Object.keys(packument.versions)

--- a/lib/utils/otplease.js
+++ b/lib/utils/otplease.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const BB = require('bluebird')
+
+const optCheck = require('figgy-pudding')({
+  prompt: { default: 'This operation requires a one-time password.\nEnter OTP:' },
+  otp: {}
+})
+
+module.exports = otplease
+function otplease (opts, fn) {
+  opts = opts.concat ? opts : optCheck(opts)
+  return BB.try(() => {
+    return fn(opts)
+  }).catch(err => {
+    if (err.code !== 'EOTP' && !(err.code === 'E401' && /one-time pass/.test(err.body))) {
+      throw err
+    } else if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      throw err
+    } else {
+      return readOTP(
+        optCheck(opts).prompt
+      ).then(otp => fn(opts.concat({ otp })))
+    }
+  })
+}
+
+function readOTP (msg, otp, isRetry) {
+  if (!msg) {
+    msg = [
+      'This command requires a one-time password (OTP) from your authenticator app.',
+      'Enter one below. You can also pass one on the command line by appending --otp=123456.',
+      'For more information, see:',
+      'https://docs.npmjs.com/getting-started/using-two-factor-authentication',
+      'Enter OTP: '
+    ].join('\n')
+  }
+  if (isRetry && otp && /^[\d ]+$|^[A-Fa-f0-9]{64,64}$/.test(otp)) return otp.replace(/\s+/g, '')
+
+  return read({ prompt: msg, default: otp || '' })
+    .then((otp) => readOTP(msg, otp, true))
+}

--- a/lib/utils/otplease.js
+++ b/lib/utils/otplease.js
@@ -26,6 +26,7 @@ function otplease (opts, fn) {
 }
 
 function readOTP (msg, otp, isRetry) {
+  const read = require('read')
   if (!msg) {
     msg = [
       'This command requires a one-time password (OTP) from your authenticator app.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -690,12 +690,6 @@
         }
       }
     },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "dev": true
-    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -1620,18 +1614,25 @@
       }
     },
     "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
+        "globby": "^6.1.0",
         "is-path-cwd": "^1.0.0",
         "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
         "rimraf": "^2.2.8"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "delayed-stream": {
@@ -1787,91 +1788,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "eslint": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
-      "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.5.0",
-        "babel-code-frame": "^6.26.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.2",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^5.2.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.11.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.5",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.0",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^4.0.3",
-        "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        }
-      }
-    },
     "eslint-config-standard": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
@@ -1927,13 +1843,13 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.3.1.tgz",
-      "integrity": "sha512-9XcVyZiQRVeFjqHw8qHNDAZcQLqaHlOGGpeYqzYh8S4JYCWTCO3yzyen8yVmA5PratfzTRWDwCOFphtDEG+w/w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.3.2.tgz",
+      "integrity": "sha512-xrdbConViY20DhGrt9FwjhDo4fr/9Yus2pYf0xJsdJaCcUzMq7+pAoNH7kSXF6V08bRHMpgDWclYbcr/Sn3hNg==",
       "dev": true,
       "requires": {
         "eslint-utils": "^1.3.0",
-        "regexpp": "^2.0.0"
+        "regexpp": "^2.0.1"
       }
     },
     "eslint-plugin-import": {
@@ -1973,20 +1889,6 @@
             "isarray": "^1.0.0"
           }
         }
-      }
-    },
-    "eslint-plugin-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
-      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-es": "^1.3.1",
-        "eslint-utils": "^1.3.1",
-        "ignore": "^4.0.2",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.0"
       }
     },
     "eslint-plugin-promise": {
@@ -2053,9 +1955,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
-          "integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg==",
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+          "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
           "dev": true
         }
       }
@@ -2231,17 +2133,6 @@
         "is-extendable": "^0.1.0"
       }
     },
-    "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
-      }
-    },
     "extglob": {
       "version": "2.0.4",
       "resolved": false,
@@ -2354,13 +2245,13 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.2.tgz",
+      "integrity": "sha512-KByBY8c98sLUAGpnmjEdWTrtrLZRtZdwds+kAL/ciFXTCb7AZgqKsAnVnYFQj1hxepwO8JKN/8AsRWwLq+RK0A==",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^2.0.2",
+        "del": "^3.0.0",
         "graceful-fs": "^4.1.2",
         "write": "^0.2.1"
       }
@@ -2842,13 +2733,12 @@
       "dev": true
     },
     "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
         "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
         "glob": "^7.0.3",
         "object-assign": "^4.0.1",
         "pify": "^2.0.0",
@@ -3079,27 +2969,6 @@
       "integrity": "sha512-9IyHupOM1h9FhYpwFITfqPMC5UjcWCzGwCGc7+jrf5CyjwKla0zcZsWVv2UUM9jRqwSH6bXr3xuHzc0tbJDedw==",
       "requires": {
         "prop-types": "^15.5.10"
-      }
-    },
-    "inquirer": {
-      "version": "5.2.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^5.5.2",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
       }
     },
     "invariant": {
@@ -4347,8 +4216,7 @@
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -5235,6 +5103,12 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -5592,6 +5466,14 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
     "read-cmd-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
@@ -5871,15 +5753,6 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "requires": {
         "aproba": "^1.1.1"
-      }
-    },
-    "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
@@ -6294,6 +6167,166 @@
         "eslint-plugin-react": "~7.11.1",
         "eslint-plugin-standard": "~4.0.0",
         "standard-engine": "~9.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+          "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "eslint": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
+          "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.5.0",
+            "babel-code-frame": "^6.26.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^4.0.0",
+            "eslint-utils": "^1.3.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^4.0.0",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.7.0",
+            "ignore": "^4.0.2",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^5.2.0",
+            "is-resolvable": "^1.1.0",
+            "js-yaml": "^3.11.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.5",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.0",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.5.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "^2.0.1",
+            "table": "^4.0.3",
+            "text-table": "^0.2.0"
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
+          "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
+          "dev": true,
+          "requires": {
+            "eslint-plugin-es": "^1.3.1",
+            "eslint-utils": "^1.3.1",
+            "ignore": "^4.0.2",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.8.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+          "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "rxjs": {
+          "version": "5.5.12",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+          "dev": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        },
+        "table": {
+          "version": "4.0.3",
+          "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+          "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.0.1",
+            "ajv-keywords": "^3.0.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        }
       }
     },
     "standard-engine": {
@@ -6597,46 +6630,6 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
       "dev": true
-    },
-    "table": {
-      "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
-      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
-        "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        }
-      }
     },
     "tacks": {
       "version": "1.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5848,9 +5848,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "npmlog": "^4.1.2",
     "read-package-json": "^2.0.13",
     "rimraf": "^2.6.2",
+    "semver": "^5.6.0",
     "spawn-wrap": "^1.4.2",
     "ssri": "^6.0.1",
     "stringify-package": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "npm-logical-tree": "^1.2.1",
     "npm-package-arg": "^6.1.0",
     "npmlog": "^4.1.2",
+    "read": "^1.0.7",
     "read-package-json": "^2.0.13",
     "rimraf": "^2.6.2",
     "semver": "^5.6.0",

--- a/test/deprecate.js
+++ b/test/deprecate.js
@@ -1,0 +1,150 @@
+'use strict'
+
+const { log } = require('libnpm')
+const { test } = require('tap')
+const tnock = require('./util/tnock.js')
+
+const cache = {
+  '_id': 'cond',
+  '_rev': '19-d458a706de1740662cd7728d7d7ddf07',
+  'name': 'cond',
+  'time': {
+    'modified': '2015-02-13T07:33:58.120Z',
+    'created': '2014-03-16T20:52:52.236Z',
+    '0.0.0': '2014-03-16T20:52:52.236Z',
+    '0.0.1': '2014-03-16T21:12:33.393Z',
+    '0.0.2': '2014-03-16T21:15:25.430Z'
+  },
+  'versions': {
+    '0.0.0': {},
+    '0.0.1': {},
+    '0.0.2': {}
+  },
+  'dist-tags': {
+    'latest': '0.0.2'
+  },
+  'description': 'Restartable error handling system',
+  'license': 'CC0'
+}
+
+log.level = process.env.LOGLEVEL || 'silent'
+const OPTS = {
+  registry: 'https://mock.reg',
+  log,
+  loglevel: log.level
+}
+
+const deprecate = require('../lib/commands/deprecate.js')
+
+test('tink deprecate an unscoped package', async t => {
+  // Clone cache and modify it for this test
+  const deprecated = JSON.parse(JSON.stringify(cache))
+  deprecated.versions = {
+    '0.0.0': {},
+    '0.0.1': { deprecated: 'make it dead' },
+    '0.0.2': {}
+  }
+
+  // Clone OPTS and modify it for this test
+  const opts = JSON.parse(JSON.stringify(OPTS))
+  opts['pkg@version'] = `${deprecated.name}@0.0.1`
+  opts.message = deprecated.versions['0.0.1'].deprecated
+
+  // Setup mock registry server
+  tnock(t, opts.registry).get('/cond?write=true').reply(200, cache)
+  tnock(t, opts.registry).put('/cond', deprecated).reply(201, { deprecated: true })
+
+  // Run the function
+  const res = await deprecate.handler(opts)
+
+  // Verify the result
+  t.equal(res.status, 201)
+})
+
+test('tink deprecate a scoped package', async t => {
+  // Clone cache and modify it for this test
+  const cacheCopy = JSON.parse(JSON.stringify(cache))
+  cacheCopy.name = '@scope/cond'
+  cacheCopy._id = '@scope/cond'
+  const deprecated = JSON.parse(JSON.stringify(cacheCopy))
+  deprecated.versions = {
+    '0.0.0': {},
+    '0.0.1': { deprecated: 'make it dead' },
+    '0.0.2': {}
+  }
+
+  // Clone OPTS and modify it for this test
+  const opts = JSON.parse(JSON.stringify(OPTS))
+  opts['pkg@version'] = `${deprecated.name}@0.0.1`
+  opts.message = deprecated.versions['0.0.1'].deprecated
+
+  // Setup mock registry server
+  tnock(t, opts.registry).get('/@scope%2fcond?write=true').reply(200, cacheCopy)
+  tnock(t, opts.registry).put('/@scope%2fcond', deprecated).reply(201, { deprecated: true })
+
+  // Run the function
+  const res = await deprecate.handler(opts)
+
+  // Verify the result
+  t.equal(res.status, 201)
+})
+
+test('tink deprecate semver range', async t => {
+  // Clone cache and modify it for this test
+  const deprecated = JSON.parse(JSON.stringify(cache))
+  deprecated.versions = {
+    '0.0.0': { deprecated: 'make it dead' },
+    '0.0.1': { deprecated: 'make it dead' },
+    '0.0.2': {}
+  }
+
+  // Clone OPTS and modify it for this test
+  const opts = JSON.parse(JSON.stringify(OPTS))
+  opts['pkg@version'] = `${deprecated.name}@<0.0.2`
+  opts.message = deprecated.versions['0.0.1'].deprecated
+
+  // Setup mock registry server
+  tnock(t, opts.registry).get('/cond?write=true').reply(200, cache)
+  tnock(t, opts.registry).put('/cond', deprecated).reply(201, { deprecated: true })
+
+  // Run the function
+  const res = await deprecate.handler(opts)
+
+  // Verify the result
+  t.equal(res.status, 201)
+})
+
+test('tink deprecate bad semver range', async t => {
+  // Clone OPTS and modify it for this test
+  const opts = JSON.parse(JSON.stringify(OPTS))
+  opts['pkg@version'] = `${cache.name}@-9001`
+  opts.message = 'make it dead'
+
+  // Test that an exception is thrown
+  t.rejects(deprecate.handler(opts), 'invalid version range: -9001')
+})
+
+test('tink deprecate a package with no semver range', async t => {
+  // Clone cache and modify it for this test
+  const deprecated = JSON.parse(JSON.stringify(cache))
+  deprecated.versions = {
+    '0.0.0': { deprecated: 'make it dead' },
+    '0.0.1': { deprecated: 'make it dead' },
+    '0.0.2': { deprecated: 'make it dead' }
+  }
+
+  // Clone OPTS and modify it for this test
+  const opts = JSON.parse(JSON.stringify(OPTS))
+  opts['pkg@version'] = deprecated.name
+  opts.message = deprecated.versions['0.0.0'].deprecated
+
+  // Setup mock registry server
+  tnock(t, opts.registry).get('/cond?write=true').reply(200, cache)
+  tnock(t, opts.registry).put('/cond', deprecated).reply(201, { deprecated: true })
+
+  // Run the function
+  const res = await deprecate.handler(opts)
+
+  // Verify the result
+  t.equal(res.status, 201)
+})


### PR DESCRIPTION
This PR adds `tink deprecate` as a command, based on the functionality of [`npm deprecate`](https://docs.npmjs.com/cli/deprecate).

Code ported from: https://github.com/npm/cli/blob/9a564a55c016642bff3e4ae58ed05a0d6370aaf3/lib/deprecate.js

Changes:
- Currently does not use `otplease` as it is [not included in `tink` yet](https://npm.community/t/tink-implement-ancillary-subcommands/3086/15?u=noelleleigh).
- Removed [explicit checking for `<message>` argument](https://github.com/npm/cli/blob/9a564a55c016642bff3e4ae58ed05a0d6370aaf3/lib/deprecate.js#L43), since `yargs` performs that validation now.
- Added `figgy-pudding` config based on the contents of [`org.jsx`](https://github.com/npm/tink/blob/c042ea29583a47f9908dcd20ad97d1f1481b3aab/lib/commands/org.jsx#L38), though no explicit logging is implemented yet.

Tested conditions:
- `tink deprecate <pkg>[@<version>] <message>`
- `tink deprecate <pkg>[@<version>]`
- `tink deprecate <pkg> <message>`
- `tink deprecate <pkg>[@<malformedversion>] <message>`

Since I don't have an npm account, I just get to the last step of the process before receiving an HTTP 401 Unauthorized response. Is there a test registry that is used for API testing, or should I just work on the main one?