### PR TITLE
make fs operations optimistic

### DIFF
--- a/lib/node/fs.js
+++ b/lib/node/fs.js
@@ -410,7 +410,7 @@ function overrideNode () {
 
   patchFn('readdirSync', readdirSync => (p, options) => {
     try {
-      return readdirSync(p, options);
+      return readdirSync(p, options)
     } catch (err) {
       if (err.code !== 'ENOENT') { throw err }
 
@@ -443,7 +443,7 @@ function overrideNode () {
           fs.writeFile(p, data, { mode }, cb)
         })
       })
-    });
+    })
   })
 
   patchFn('open', open => (p, flags, mode, cb) => {
@@ -481,7 +481,7 @@ function overrideNode () {
     try {
       return openSync(p, flags, mode)
     } catch (err) {
-      if (err.code !== 'ENOENT') { throw err; }
+      if (err.code !== 'ENOENT') { throw err }
 
       const resolved = pkglock.resolve(p)
       if (!resolved) {
@@ -565,7 +565,7 @@ function overrideNode () {
     try {
       return pkglock.readSync(resolved).toString('utf8')
     } catch (err) {
-      return undefined;
+      return undefined
     }
   }, process.binding('fs'), {})
 

--- a/lib/node/fs.js
+++ b/lib/node/fs.js
@@ -56,23 +56,26 @@ function overrideAPISync (module, name, arg) {
   }
   const old = module[name]
   module[name] = function () {
-    const p = arguments[arg]
-    const resolved = pkglock.resolve(p)
-    if (resolved == null) { return old.apply(this, arguments) }
-    if (resolved.isDir) {
-      isDirError(p, name)
-    }
-    if (!resolved) {
-      notFoundError(p)
-    }
+    try {
+      return old.apply(this, arguments)
+    } catch (err) {
+      const p = arguments[arg]
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        notFoundError(p)
+      }
+      if (resolved.isDir) {
+        isDirError(p, name)
+      }
 
-    const stat = pkglock.statSync(resolved, true)
-    if (!stat) {
-      notFoundError(p)
-    }
+      const stat = pkglock.statSync(resolved, true)
+      if (!stat) {
+        notFoundError(p)
+      }
 
-    arguments[arg] = stat.cachePath
-    return old.apply(this, arguments)
+      arguments[arg] = stat.cachePath
+      return old.apply(this, arguments)
+    }
   }
 }
 
@@ -100,37 +103,36 @@ function overrideNode () {
     try {
       return lstatSync(p)
     } catch (err) {
-      if (err.code !== 'ENOENT') {
-        throw err
+      if (err.code !== 'ENOENT') { throw err }
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        notFoundError(p)
       } else {
-        const resolved = pkglock.resolve(p)
-        if (!resolved) {
-          return notFoundError(p)
-        } else {
-          const stats = pkglock.statSync(resolved)
-          if (!stats) {
-            notFoundError(p)
-          }
-          return stats
+        const stats = pkglock.statSync(resolved)
+        if (!stats) {
+          notFoundError(p)
         }
+        return stats
       }
     }
   })
 
   patchFn('lstat', lstat => (p, cb) => {
-    return lstat(p, (err, stat) => {
-      if (!err) { return cb(err, stat) }
+    return lstat(p, (err, stats) => {
+      if (!err || err.code !== 'ENOENT') {
+        return cb(err, stats)
+      }
       const resolved = pkglock.resolve(p)
       if (!resolved) {
         return notFoundError(p, cb)
-      } else {
-        pkglock.stat(resolved).then(stat => {
-          if (!stat) {
-            notFoundError(p, cb)
-          }
-          cb(null, stat)
-        }, cb)
       }
+      pkglock.stat(resolved).then(newStats => {
+        if (newStats) {
+          cb(null, newStats)
+        } else {
+          return notFoundError(p, cb)
+        }
+      }, cb)
     })
   })
 
@@ -138,44 +140,45 @@ function overrideNode () {
     try {
       return statSync(p)
     } catch (err) {
-      if (err.code !== 'ENOENT') {
-        throw err
+      if (err.code !== 'ENOENT') { throw err }
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        notFoundError(p)
       } else {
-        const resolved = pkglock.resolve(p)
-        if (!resolved) {
-          return notFoundError(p)
-        } else {
-          const stats = pkglock.statSync(resolved)
-          if (!stats) {
-            notFoundError(p)
-          }
-          return stats
+        const stats = pkglock.statSync(resolved)
+        if (!stats) {
+          notFoundError(p)
         }
+        return stats
       }
     }
   })
 
   patchFn('stat', stat => (p, cb) => {
-    return stat(p, (err, stat) => {
-      if (!err) { return cb(err, stat) }
+    return stat(p, (err, stats) => {
+      if (!err || err.code !== 'ENOENT') {
+        cb(err, stats)
+      }
       const resolved = pkglock.resolve(p)
       if (!resolved) {
         return notFoundError(p, cb)
-      } else {
-        pkglock.stat(resolved).then(stat => {
-          if (!stat) {
-            notFoundError(p, cb)
-          }
-          cb(null, stat)
-        }, cb)
       }
+      pkglock.stat(resolved).then(newStats => {
+        if (!newStats) {
+          return notFoundError(p, cb)
+        }
+        cb(null, newStats)
+      }, cb)
     })
   })
 
   patchFn('statSyncNoException', statSyncNoException => p => {
-    const ret = statSyncNoException(p)
-    if (ret) {
-      return ret
+    const nativeResult = statSyncNoException(p)
+    if (nativeResult) { return nativeResult }
+
+    const resolved = pkglock.resolve(p)
+    if (!resolved) {
+      return false
     } else {
       const resolved = pkglock.resolve(p)
       if (!resolved) {
@@ -190,120 +193,128 @@ function overrideNode () {
     }
   })
 
-  patchFn('realpathSync', realpathSync => (p, ...args) => {
+  patchFn('realpathSync', realpathSync => function (p) {
     try {
-      return realpathSync(p, ...args)
+      return realpathSync.apply(this, arguments)
     } catch (err) {
       if (err.code !== 'ENOENT') { throw err }
       const resolved = pkglock.resolve(p)
       if (!resolved) {
         return notFoundError(p)
-      } else {
-        return resolved.resolvedPath
       }
+      return resolved.resolvedPath
     }
   })
 
   patchFn('realpath', realpath => function (p, cache, cb) {
-    realpath(p, cache, (err, rp) => {
-      if (err && err.code !== 'ENOENT') { return cb(err) }
-      if (!err) { return cb(null, rp) }
-      const resolved = pkglock.resolve(p)
-      if (typeof cache === 'function') {
-        cb = cache
-        cache = void 0
-      }
+    if (typeof cache === 'function') {
+      cb = cache
+      cache = undefined
+    }
 
-      process.nextTick(() => {
-        if (resolved) {
-          cb(null, resolved.resolvedPath)
-        } else {
-          notFoundError(p, cb)
-        }
-      })
+    realpath.call(this, p, cache, (err, resolvedPath) => {
+      if (!err || err.code !== 'ENOENT') {
+        cb(err, resolvedPath)
+      }
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        return notFoundError(p, cb)
+      }
+      cb(null, resolved.resolvedPath)
     })
   })
 
   patchFn('exists', exists => (p, cb) => {
-    const resolved = pkglock.resolve(p)
-    if (resolved == null) {
-      exists(p, cb)
-    } else {
-      process.nextTick(() => cb(null, !!resolved))
-    }
+    exists(p, (doesExist) => {
+      if (doesExist) {
+        cb(true)
+      } else {
+        const resolved = pkglock.resolve(p)
+        cb(Boolean(resolved))
+      }
+    })
   })
 
   patchFn(util.promisify.custom, custom => async p => {
-    const resolved = pkglock.resolve(p)
-    if (resolved == null) { return custom(p) }
-    return !!resolved
+    const doesExist = await custom(p)
+    if (doesExist) {
+      return true
+    } else {
+      const resolved = pkglock.resolve(p)
+      return Boolean(resolved)
+    }
   }, fs.exists, gfs.exists) // eslint-disable-line
 
   patchFn('existsSync', existsSync => p => {
-    const resolved = pkglock.resolve(p)
-    if (resolved == null) { return existsSync(p) }
-    return !!resolved
+    const doesExist = existsSync(p)
+    if (doesExist) {
+      return true
+    } else {
+      const resolved = pkglock.resolve(p)
+      return Boolean(resolved)
+    }
   })
 
   patchFn('access', access => (p, mode, cb) => {
-    const resolved = pkglock.resolve(p)
-    if (resolved == null) {
-      return access(p, mode, cb)
-    }
     if (typeof mode === 'function') {
       cb = mode
       mode = fs.constants.F_OK
     }
-    if (!resolved) {
-      return notFoundError(p, cb)
-    } else if (resolved.isDir) {
-      process.nextTick(() => {
+
+    access(p, mode, (err) => {
+      if (!err) { return cb(null) }
+      if (err.code !== 'ENOENT') { return cb(err) }
+
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        return notFoundError(p, cb)
+      }
+
+      if (resolved.isDir) {
         if (mode === fs.constants.F_OK || fs.constants.R_OK & mode) {
           cb(null)
         } else {
           accessError(p, cb)
         }
-      })
-    } else {
-      pkglock.stat(resolved).then(stat => {
-        if (!stat) {
-          return notFoundError(p, cb)
-        }
-        access(stat.cachePath, mode, cb)
-      }, cb)
-    }
+      } else {
+        pkglock.stat(resolved).then(stat => {
+          if (!stat) {
+            return notFoundError(p, cb)
+          }
+          access(stat.cachePath, mode, cb)
+        }, cb)
+      }
+    })
   })
 
   patchFn('accessSync', accessSync => (p, mode) => {
-    const resolved = pkglock.resolve(p)
-    if (resolved == null) {
-      return accessSync(p, mode)
-    }
     if (mode == null) {
       mode = fs.constants.F_OK
     }
-    if (!resolved) {
-      return notFoundError(p)
-    } else if (resolved.isDir) {
-      if (mode === fs.constants.F_OK || fs.constants.R_OK & mode) {
-        // undefined
+    try {
+      return accessSync(p, mode)
+    } catch(err) {
+      const resolved = pkglock.resolve(p)
+
+      if (!resolved) {
+        throw err
+      } else if (resolved.isDir) {
+        if (mode === fs.constants.F_OK || fs.constants.R_OK & mode) {
+          // undefined
+        } else {
+          return accessError(p)
+        }
       } else {
-        return accessError(p)
+        const stat = pkglock.statSync(resolved)
+        if (!stat) {
+          notFoundError(p)
+        }
+        return accessSync(stat.cachePath, mode)
       }
-    } else {
-      const stat = pkglock.statSync(resolved)
-      if (!stat) {
-        notFoundError(p)
-      }
-      return fs.accessSync(stat.cachePath, mode)
     }
   })
 
   patchFn('readFile', readFile => (p, options, cb) => {
-    const resolved = pkglock.resolve(p)
-    if (resolved == null) {
-      return readFile(p, options, cb)
-    }
     if (typeof options === 'function') {
       cb = options
       options = {
@@ -320,28 +331,30 @@ function overrideNode () {
     } else if (typeof options !== 'object') {
       throw new TypeError('badarg')
     }
-    if (resolved.isDir) {
-      return isDirError(p, 'read', cb)
-    } else if (!resolved) {
-      return notFoundError(p, cb)
-    }
-    const { encoding } = options
-    pkglock.read(resolved).then(data => {
-      if (encoding) {
-        data = data.toString(encoding)
+
+    readFile(p, options, (err, data) => {
+      if (!err || err.code !== 'ENOENT') {
+        return cb(err, data)
       }
-      cb(null, data)
-    }, cb)
+
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        return notFoundError(p, cb)
+      } else if (resolved.isDir) {
+        return isDirError(p, 'read', cb)
+      }
+
+      const { encoding } = options
+      pkglock.read(resolved).then(data => {
+        if (encoding) {
+          data = data.toString(encoding)
+        }
+        cb(null, data)
+      }, cb)
+    })
   })
 
   patchFn('readFileSync', readFileSync => (p, options) => {
-    const resolved = pkglock.resolve(p)
-    if (resolved == null) { return readFileSync(p, options) }
-    if (resolved.isDir) {
-      isDirError(p, 'read')
-    } else if (!resolved) {
-      notFoundError(p)
-    }
     if (!options) {
       options = {
         encoding: null
@@ -353,68 +366,76 @@ function overrideNode () {
     } else if (typeof options !== 'object') {
       throw new TypeError('Bad arguments')
     }
-    const { encoding } = options
-    const data = pkglock.readSync(resolved)
-    if (encoding) {
-      return data.toString(encoding)
-    } else {
-      return data
+
+    try {
+      return readFileSync(p, options)
+    } catch (err) {
+      if (err.code !== 'ENOENT') { throw err }
+
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        return notFoundError(p)
+      } else if (resolved.isDir) {
+        return isDirError(p, 'read')
+      }
+
+      const { encoding } = options
+      const data = pkglock.readSync(resolved)
+      if (encoding) {
+        return data.toString(encoding)
+      } else {
+        return data
+      }
     }
   })
 
-  patchFn('readdir', readdir => (p, cb) => {
-    let found = false
-    readdir(p, (err, files) => {
-      if (err && err.code !== 'ENOENT') { return cb(err) }
-      if (!err) { found = true }
-      files = files || []
-      const resolved = pkglock.resolve(p)
-      if (resolved && resolved.isDir) {
-        files.push(...Object.keys(resolved.dir))
-        found = true
-      } else {
-        if (!found) {
-          return notFoundError(p, cb)
-        } else if (resolved && !resolved.isDir) {
-          return notDirError(cb)
-        }
+  patchFn('readdir', readdir => (p, options, cb) => {
+    if (!cb) { cb = options; options = undefined }
+
+    return readDir(p, options, (err, files) => {
+      if (!err || err.code !== 'ENOENT') {
+        return cb(err, files)
       }
-      process.nextTick(() => cb(null, [...new Set(files)]))
+
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        return notFoundError(p, cb)
+      } else if (!resolved.isDir) {
+        return notDirError(cb)
+      }
+      
+      cb(null, Object.keys(resolved.dir))
     })
   })
 
-  patchFn('readdirSync', readdirSync => p => {
-    let found = false
-    let files = []
+  patchFn('readdirSync', readdirSync => (p, options) => {
     try {
-      files = readdirSync(p)
-      found = true
+      return readdirSync(p, options);
     } catch (err) {
       if (err.code !== 'ENOENT') { throw err }
-    }
-    const resolved = pkglock.resolve(p)
-    if (resolved && resolved.isDir) {
-      files.push(...Object.keys(resolved.dir))
-      found = true
-    } else {
-      if (!found) {
-        notFoundError(p)
-      } else if (resolved && !resolved.isDir) {
-        notDirError()
+
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        return notFoundError(p)
+      } else if (!resolved.isDir) {
+        return notDirError()
       }
+      return Object.keys(resolved.dir)
     }
     return [...new Set(files)]
   })
 
   patchFn('chmod', chmod => (p, mode, cb) => {
-    const resolved = pkglock.resolve(p)
-    if (resolved == null) {
-      return chmod(p, mode, cb)
-    } else if (!resolved) {
-      notFoundError(p)
-    } else if (resolved.isDir) {
-      mkdirp(p, { mode }, cb)
-    } else {
+    return chmod(p, mode, (err) => {
+      if (!err || err.code !== 'ENOENT') { cb(err) }
+
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        return notFoundError(p, cb)
+      } else if (resolved.isDir) {
+        return mkdirp(p, { mode }, cb)
+      }
+
       return mkdirp(path.dirname(p), err => {
         if (err) { cb(err) }
         fs.readFile(p, (err, data) => {
@@ -422,48 +443,53 @@ function overrideNode () {
           fs.writeFile(p, data, { mode }, cb)
         })
       })
-    }
+    });
   })
 
   patchFn('open', open => (p, flags, mode, cb) => {
     if (!cb) { cb = mode; mode = undefined }
     open(p, flags, mode, (err, fd) => {
       if (!err || err.code !== 'ENOENT') { return cb(err, fd) }
+      
       const resolved = pkglock.resolve(p)
       if (!resolved) {
-        notFoundError(p, cb)
+        return notFoundError(p, cb)
       } else if (resolved.isDir) {
-        isDirError(p, 'read', cb)
-      } else {
-        pkglock.stat(resolved, true).then(stat => {
-          if (!stat) {
-            notFoundError(p)
-          } else if (flags === 'r') {
-            // If we're only reading, we can read straight off cacache
-            return open(stat.cachePath, flags, mode, cb)
-          } else {
-            fs.copyFile(stat.cachePath, p, err => {
-              if (err) { return cb(err) }
-              fs.chmod(p, 0o755, err => {
-                if (err) { return cb(err) }
-                open(p, flags, mode, cb)
-              })
-            })
-          }
-        }).catch(cb)
+        return isDirError(p, 'read', cb)
       }
+
+      pkglock.stat(resolved, true).then(stat => {
+        if (!stat) {
+          notFoundError(p)
+        } else if (flags === 'r') {
+          // If we're only reading, we can read straight off cacache
+          return open(stat.cachePath, flags, mode, cb)
+        } else {
+          fs.copyFile(stat.cachePath, p, err => {
+            if (err) { return cb(err) }
+            fs.chmod(p, 0o755, err => {
+              if (err) { return cb(err) }
+              open(p, flags, mode, cb)
+            })
+          })
+        }
+      }).catch(cb)
     })
   })
 
   patchFn('openSync', openSync => (p, flags, mode) => {
-    const resolved = pkglock.resolve(p)
-    if (resolved == null) {
+    try {
       return openSync(p, flags, mode)
-    } else if (!resolved) {
-      notFoundError(p)
-    } else if (resolved.isDir) {
-      isDirError(p, 'read')
-    } else {
+    } catch (err) {
+      if (err.code !== 'ENOENT') { throw err; }
+
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        return notFoundError(p)
+      } else if (resolved.isDir) {
+        return isDirError(p, 'read')
+      }
+
       const stat = pkglock.statSync(resolved, true)
       if (!stat) {
         notFoundError(p)
@@ -479,10 +505,18 @@ function overrideNode () {
   })
 
   patchFn('createReadStream', createReadStream => (p, opts) => {
-    const resolved = pkglock.resolve(p)
-    if (!resolved || resolved.isDir) {
+    try {
       return createReadStream(p, opts)
-    } else {
+    } catch (err) {
+      if (err.code !== 'ENOENT') { throw err }
+
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        return notFoundError(p)
+      } else if (resolved.isDir) {
+        return isDirError(p, 'read')
+      }
+
       const stat = pkglock.statSync(resolved, true)
       if (!stat) {
         // Should emit ENOENT
@@ -499,10 +533,18 @@ function overrideNode () {
   })
 
   patchFn('createWriteStream', createWriteStream => (p, opts) => {
-    const resolved = pkglock.resolve(p)
-    if (!resolved || resolved.isDir) {
+    try {
       return createWriteStream(p, opts)
-    } else {
+    } catch (err) {
+      if (err.code !== 'ENOENT') { throw err }
+
+      const resolved = pkglock.resolve(p)
+      if (!resolved) {
+        return notFoundError(p)
+      } else if (resolved.isDir) {
+        return isDirError(p, 'write')
+      }
+
       const stat = pkglock.statSync(resolved, true)
       if (!stat) {
         // Should emit ENOENT
@@ -516,21 +558,26 @@ function overrideNode () {
   })
 
   patchFn('internalModuleReadJSON', internalModuleReadJSON => p => {
+    const maybeJson = internalModuleReadJSON(p)
+    if (maybeJson !== undefined) { return maybeJson }
     const resolved = pkglock.resolve(p)
-    if (resolved == null) { return internalModuleReadJSON(p) }
     if (!resolved || resolved.isDir) { return }
     try {
       return pkglock.readSync(resolved).toString('utf8')
     } catch (err) {
+      return undefined;
     }
   }, process.binding('fs'), {})
 
   patchFn('internalModuleStat', internalModuleStat => p => {
+    const returnCode = internalModuleStat(p)
+    if (returnCode >= 0) { return returnCode }
+
     const resolved = pkglock.resolve(p)
-    if (resolved == null) { return internalModuleStat(p) }
     if (resolved && resolved.isFile) { return 0 }
     if (resolved && resolved.isDir) { return 1 }
     if (!resolved && path.basename(p) === 'node_modules') { return 1 }
+    if (!resolved) { return returnCode }
     return -34
   }, process.binding('fs'), {})
 

--- a/lib/pkglock.js
+++ b/lib/pkglock.js
@@ -38,14 +38,6 @@ function resolve (...p) {
     }
     [, pkgName, subPath, filePath] = subPath.match(/^[/\\]((?:@[^/\\]+[/\\])?[^/\\]+)([/\\]?(.*))/)
     let res = resolveEntity(process.tink.cache, scope, pkgName, filePath)
-    if (res && res.isFile) {
-      // If the file already exists in the filesystem, use the filesystem
-      // version.
-      try {
-        (fs.statSync.orig || fs.statSync)(resolved, true)
-        return null
-      } catch (e) {}
-    }
     if (res) {
       const pkg = scope.dependencies[pkgName]
       pkg.name = pkgName


### PR DESCRIPTION
This changes the fs functions to try the normal impl first before calling pkglock.resolve.

It looks like you went ahead and did some of these already over the last few days- I didn't know you wanted them done sooner than the weekend or I wouldn't have volunteered to do them, sorry to keep you waiting.

The merge conflicts may not have been resolved properly because of that; I've checked **Allow edits from maintainers** so please do whatever you feel makes the most sense.