### PR TITLE
feat(build): implement build command

### DIFF
--- a/bin/tink.js
+++ b/bin/tink.js
@@ -5,6 +5,7 @@ require('../lib/node/index.js')
 const CMDS = new Map([
   ['access', require('../lib/commands/access.jsx')],
   ['add', require('../lib/commands/add.js')],
+  ['build', require('../lib/commands/build.js')],
   ['deprecate', require('../lib/commands/deprecate.js')],
   ['org', require('../lib/commands/org.jsx')],
   ['ping', require('../lib/commands/ping.js')],

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -12,11 +12,9 @@ const Build = module.exports = {
 }
 
 async function build (argv) {
-  const findPrefix = require('find-npm-prefix')
-  const readJson = require('read-package-json')
+  const libnpm = require('libnpm')
   const figgyPudding = require('figgy-pudding')
   const npmConfig = require('../config.js')
-  const libnpm = require('libnpm')
   const log = require('npmlog')
 
   const cwd = process.cwd()
@@ -36,21 +34,12 @@ async function build (argv) {
   })
   const opts = BuildConfig(npmConfig().concat(argv).concat({ log }))
 
-  findPrefix(process.cwd()).then(prefix => {
-    const packageJson = `${prefix}/package.json`
-    readJson(
-      packageJson,
-      console.error,
-      false,
-      async (er, data) => {
-        if (er) {
-          console.error(`There was an error reading ${packageJson}`)
-        }
-        if (data) {
-          await libnpm.runScript(data, 'build', cwd, opts)
-            .catch(e => console.error(e))
-        }
-      }
-    )
-  })
+  libnpm.getPrefix(process.cwd())
+    .then(prefix => {
+      const packageJSON = `${prefix}/package.json`
+      libnpm.readJSON(packageJSON)
+        .then(async pkg => await libnpm.runScript(pkg, 'build', cwd, opts))
+        .catch(async e => await libnpm.log.error(e))
+    })
+    .catch(async e => await libnp.log.error(e))
 }

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -33,7 +33,6 @@ async function build (argv) {
     scriptShell: {}
   })
   const opts = BuildConfig(npmConfig().concat(argv).concat({ log }))
-
   const prefix = await libnpm.getPrefix(process.cwd())
   const packageJSON = `${prefix}/package.json`
   const pkg = await libnpm.readJSON(packageJSON)

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -33,11 +33,11 @@ async function build (argv) {
     scriptShell: {}
   })
   const opts = BuildConfig(npmConfig().concat(argv).concat({ log }))
-  return await libnpm.getPrefix(process.cwd())
-    .then(prefix => {
-      const packageJSON = `${prefix}/package.json`
-      libnpm.readJSON(packageJSON)
-        .then(async pkg => await libnpm.runScript(pkg, 'build', cwd, opts))
-      return true
-    })
+
+  const prefix = await libnpm.getPrefix(process.cwd())
+  const packageJSON = `${prefix}/package.json`
+  const pkg = await libnpm.readJSON(packageJSON)
+
+  await libnpm.runScript(pkg, 'build', cwd, opts)
+  return true
 }

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -19,7 +19,7 @@ async function build (argv) {
 
   const cwd = process.cwd()
   const BuildConfig = figgyPudding({
-    log: { default: () => log },
+    log: {},
     dir: { default: cwd },
     production: { default: false },
     nodeOptions: { default: {} },
@@ -33,13 +33,11 @@ async function build (argv) {
     scriptShell: {}
   })
   const opts = BuildConfig(npmConfig().concat(argv).concat({ log }))
-
-  libnpm.getPrefix(process.cwd())
+  return await libnpm.getPrefix(process.cwd())
     .then(prefix => {
       const packageJSON = `${prefix}/package.json`
       libnpm.readJSON(packageJSON)
         .then(async pkg => await libnpm.runScript(pkg, 'build', cwd, opts))
-        .catch(async e => await libnpm.log.error(e))
+      return true
     })
-    .catch(async e => await libnp.log.error(e))
 }

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -1,0 +1,56 @@
+'use strict'
+const Build = module.exports = {
+  command: 'build',
+  describe: 'Executes the configured build script, if present, or executes ' +
+    ' silently',
+  builder (y) {
+    return y.help().alias('help', 'h')
+      .options(Build.options)
+  },
+  options: Object.assign(require('../common-opts.js', {})),
+  handler: async argv => build(argv)
+}
+
+async function build (argv) {
+  const findPrefix = require('find-npm-prefix')
+  const readJson = require('read-package-json')
+  const figgyPudding = require('figgy-pudding')
+  const npmConfig = require('../config.js')
+  const libnpm = require('libnpm')
+  const log = require('npmlog')
+
+  const cwd = process.cwd()
+  const BuildConfig = figgyPudding({
+    log: { default: () => log },
+    dir: { default: cwd },
+    production: { default: false },
+    nodeOptions: { default: {} },
+    config: { default: {} },
+    unsafePerm: { default: false },
+    scriptsPrependNodePath: { default: false },
+    ignoreScripts: { default: false },
+    user: {},
+    group: {},
+    stdio: {},
+    scriptShell: {}
+  })
+  const opts = BuildConfig(npmConfig().concat(argv).concat({ log }))
+
+  findPrefix(process.cwd()).then(prefix => {
+    const packageJson = `${prefix}/package.json`
+    readJson(
+      packageJson,
+      console.error,
+      false,
+      async (er, data) => {
+        if (er) {
+          console.error(`There was an error reading ${packageJson}`)
+        }
+        if (data) {
+          await libnpm.runScript(data, 'build', cwd, opts)
+            .catch(e => console.error(e))
+        }
+      }
+    )
+  })
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "tish": "./bin/tish.sh"
   },
   "scripts": {
-    "build": "echo hey man",
     "prerelease": "npm t",
     "release": "standard-version -s",
     "postrelease": "npm publish && git push --follow-tags",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "tish": "./bin/tish.sh"
   },
   "scripts": {
+    "build": "echo hey man",
     "prerelease": "npm t",
     "release": "standard-version -s",
     "postrelease": "npm publish && git push --follow-tags",

--- a/test/build.js
+++ b/test/build.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const { test } = require('tap')
+const build = require('../lib/commands/build.js')
+
+test('execute "build" handler & assert truthy returned value', async t => {
+  t.equal(await build.handler(), true)
+})


### PR DESCRIPTION
Refer to [tink-build topic](https://npm.community/t/tink-implement-tink-build/3313).

- [x] Implementation
- [x] Add unit test

##### Local Testing

###### Without `build` run-script
No script is run.
```sh
→ tink build
```

###### With a dummy script, i.e. `"build": "echo Bingo!"`
`build` run-script is executed to print `Bingo!`.
```sh
→ tink build

> tink@0.14.0 build /Users/bchen/github/tink
> echo Bingo!

Bingo!
```