### PR TITLE
fix(otplease): promisify `read`

### DIFF
--- a/lib/utils/otplease.js
+++ b/lib/utils/otplease.js
@@ -26,7 +26,7 @@ function otplease (opts, fn) {
 }
 
 function readOTP (msg, otp, isRetry) {
-  const read = require('read')
+  const read = BB.promisify(require('read'))
   if (!msg) {
     msg = [
       'This command requires a one-time password (OTP) from your authenticator app.',


### PR DESCRIPTION
`read` doesn't return a promise.
See https://www.npmjs.com/package/read

Using `otplease`, it throws the next error:

<img width="661" alt="screenshot 2018-11-16 at 02 10 34" src="https://user-images.githubusercontent.com/15221596/48591676-2ce4af80-e945-11e8-96b1-07291889d99d.png">

