### PR TITLE
refactor(access): Improve Access Implementation

### DIFF
--- a/lib/commands/access.jsx
+++ b/lib/commands/access.jsx
@@ -135,21 +135,19 @@ async function accessLsCollaborators (argv) {
       await libnpm.access.lsCollaborators(argv.spec, argv.user, opts)
     render(opts, collaborators)
   } else {
-    const prefix = await libnpm.findPrefix(process.cwd())
+    const prefix = await libnpm.getPrefix(process.cwd())
     if (prefix) {
-      libnpm.readJson(
+      const data = await libnpm.readJSON(
         `${prefix}/package.json`,
         console.error,
-        false,
-        async (er, data) => {
-          if (er) {
-            console.error('There was an error reading the file')
-          }
-          const collaborators =
-            await libnpm.access.lsCollaborators(data.name, argv.user, opts)
-          render(opts, collaborators)
-        }
+        false
       )
+
+      if (data) {
+        const collaborators =
+          await libnpm.access.lsCollaborators(data.name, argv.user, opts)
+        render(opts, collaborators)
+      }
     }
   }
 }

--- a/lib/commands/access.jsx
+++ b/lib/commands/access.jsx
@@ -75,7 +75,7 @@ const parseOpts = argv => Config(npmConfig().concat(argv).concat({
   log: require('npmlog')
 }))
 
-const render = (opts, content) => {
+const render = (opts, content = {}) => {
   const { h, renderToString } = require('ink')
   const Table = require('ink-table').default
 
@@ -96,22 +96,18 @@ const render = (opts, content) => {
 
 async function accessPublic (argv) {
   await libnpm.access.public(argv.spec, parseOpts(argv))
-    .catch(e => console.error(e))
 }
 
 async function accessRestricted (argv) {
   await libnpm.access.restricted(argv.spec, parseOpts(argv))
-    .catch(e => console.error(e))
 }
 
 async function accessGrant (argv) {
   await access.grant(argv.spec, argv.team, argv.permissions, parseOpts(argv))
-    .catch(e => console.error(e))
 }
 
 async function accessRevoke (argv) {
   await libnpm.access.revoke(argv.spec, argv.team, parseOpts(argv))
-    .catch(e => console.error(e))
 }
 
 async function accessLsPackages (argv) {
@@ -127,24 +123,20 @@ async function accessLsPackages (argv) {
   // TODO: error when opts is used as 2nd param in .lsPackages
   const packages =
     await libnpm.access.lsPackages(entity)
-      .catch(e => console.error(e))
   render(opts, packages)
 }
 
 async function accessLsCollaborators (argv) {
-  const findPrefix = require('find-npm-prefix')
-  const readJson = require('read-package-json')
   const opts = parseOpts(argv)
 
   if (argv.spec) {
     const collaborators =
       await libnpm.access.lsCollaborators(argv.spec, argv.user, opts)
-        .catch(e => console.error(e))
     render(opts, collaborators)
   } else {
-    const prefix = await findPrefix(process.cwd())
+    const prefix = await libnpm.findPrefix(process.cwd())
     if (prefix) {
-      readJson(
+      libnpm.readJson(
         `${prefix}/package.json`,
         console.error,
         false,
@@ -154,7 +146,6 @@ async function accessLsCollaborators (argv) {
           }
           const collaborators =
             await libnpm.access.lsCollaborators(data.name, argv.user, opts)
-              .catch(e => console.error(e))
           render(opts, collaborators)
         }
       )

--- a/lib/commands/access.jsx
+++ b/lib/commands/access.jsx
@@ -111,13 +111,14 @@ async function accessRevoke (argv) {
 }
 
 async function accessLsPackages (argv) {
-  const getPackagesByCurrentUser = () => {
-    // TODO: grab current authenticated user from pending whoami support
+  const getPackagesByCurrentUser = async () => {
+    const whoami = require('./whoami')
+    return await whoami.handler({ silent: true })
   }
 
   const entity = argv.entity
     ? argv.entity
-    : getPackagesByCurrentUser()
+    : await getPackagesByCurrentUser()
 
   const opts = parseOpts(argv)
   // TODO: error when opts is used as 2nd param in .lsPackages

--- a/lib/commands/access.jsx
+++ b/lib/commands/access.jsx
@@ -142,7 +142,8 @@ async function accessLsCollaborators (argv) {
         .catch(e => console.error(e))
     render(opts, collaborators)
   } else {
-    findPrefix(process.cwd()).then(prefix => {
+    const prefix = await findPrefix(process.cwd())
+    if (prefix) {
       readJson(
         `${prefix}/package.json`,
         console.error,
@@ -157,7 +158,7 @@ async function accessLsCollaborators (argv) {
           render(opts, collaborators)
         }
       )
-    })
+    }
   }
 }
 


### PR DESCRIPTION
Since #12 is merged for `tink access`, this follow-up PR attempts to improve:
* use `await` to rewrite `.then` syntax
* remove unneeded `.catch` on await code
* address an `TODO` item:
  * call `whoami` when no "user" is provided to `ls-packages` option.
