### PR TITLE
feat(view): add PackageSummary

### DIFF
--- a/lib/components/view.jsx
+++ b/lib/components/view.jsx
@@ -2,6 +2,7 @@ const semver = require('semver')
 const byteSize = require('byte-size')
 const relativeDate = require('tiny-relative-date')
 const columns = require('cli-columns')
+const sliceAnsi = require('slice-ansi')
 
 const {
   h, // eslint-disable-line
@@ -45,6 +46,11 @@ class Columns extends Component {
       sort: false
     })
   }
+
+const Line = ({ width, children }) => {
+  const string = children.map(renderToString).join('')
+  const sliced = sliceAnsi(string, 0, width)
+  return string === sliced ? string : sliceAnsi(string, 0, width - 3) + '...'
 }
 
 const packageValueObjectItems = function ({ field, value, props, maxItems }) {
@@ -285,6 +291,7 @@ module.exports.PackageFields = PackageFields
 
 class PackageSummary extends Component {
   render () {
+    const width = process.env.COLUMNS - 2
     let { packument, spec } = this.props
     let [data] = getData(packument, spec)
     let views = data.map((pkg) => {
@@ -309,8 +316,12 @@ class PackageSummary extends Component {
           </span>
         </div>
 
-        <div>{pkg.description}</div>
-        <span><PackageValue {...getProps('homepage')} /> - <PackageValue {...getProps('keywords')} /></span>
+        <div><Line width={width}>{pkg.description}</Line></div>
+        <span>
+          <Line width={width}>
+            <PackageValue {...getProps('homepage')} /> - <PackageValue {...getProps('keywords')} />
+          </Line>
+        </span>
       </Box>
     })
 
@@ -324,6 +335,7 @@ module.exports.PackageSummary = PackageSummary
 
 class PackageSearchResult extends Component {
   render () {
+    const width = process.env.COLUMNS - 2
     const { result: { package: pkg } } = this.props
     return <Box>
       <div>
@@ -337,8 +349,12 @@ class PackageSearchResult extends Component {
         </span>
       </div>
 
-      <div>{pkg.description}</div>
-      <span><PackageValue field='homepage' value={pkg.links.homepage} /> - <PackageValue field='keywords' value={pkg.keywords} /></span>
+      <div><Line width={width}>{pkg.description}</Line></div>
+      <span>
+        <Line width={width}>
+          <PackageValue field='homepage' value={pkg.links.homepage} /> - <PackageValue field='keywords' value={pkg.keywords} />
+        </Line>
+      </span>
     </Box>
   }
 }

--- a/lib/components/view.jsx
+++ b/lib/components/view.jsx
@@ -133,7 +133,7 @@ class PackageValueUrl extends Component {
 
 class PackageValuePerson extends Component {
   render () {
-    let { name, url, email } = this.props
+    let { name, username, url, email } = this.props
     let parts = []
 
     if (email) {
@@ -144,7 +144,7 @@ class PackageValuePerson extends Component {
     }
 
     return <span>
-      <Color yellow>{name}</Color>
+      <Color yellow>{name || username}</Color>
       {parts}
     </span>
   }
@@ -285,7 +285,7 @@ module.exports.PackageFields = PackageFields
 
 class PackageSummary extends Component {
   render () {
-    let { packument, spec, json } = this.props
+    let { packument, spec } = this.props
     let [data] = getData(packument, spec)
     let views = data.map((pkg) => {
       const getProps = (field) => ({
@@ -321,6 +321,28 @@ class PackageSummary extends Component {
   }
 }
 module.exports.PackageSummary = PackageSummary
+
+class PackageSearchResult extends Component {
+  render () {
+    const { result: { package: pkg } } = this.props
+    return <Box>
+      <div>
+        <PackageValue field='_id' value={pkg.name + '@' + pkg.version} />
+        <span> | </span>
+        <span>
+          <span>published </span>
+          <PackageValue field='_time' value={pkg.date.toString()} />
+          <span> by </span>
+          <PackageValue field='_npmUser' value={pkg.publisher} />
+        </span>
+      </div>
+
+      <div>{pkg.description}</div>
+      <span><PackageValue field='homepage' value={pkg.links.homepage} /> - <PackageValue field='keywords' value={pkg.keywords} /></span>
+    </Box>
+  }
+}
+module.exports.PackageSearchResult = PackageSearchResult
 
 class PackageView extends Component {
   render () {

--- a/lib/components/view.jsx
+++ b/lib/components/view.jsx
@@ -11,6 +11,7 @@ const {
   Color,
   Indent
 } = require('ink')
+const Box = require('ink-box')
 
 const MAX_ITEMS = 6
 const ROW_WIDTH = 4
@@ -281,6 +282,45 @@ class PackageFields extends Component {
   }
 }
 module.exports.PackageFields = PackageFields
+
+class PackageSummary extends Component {
+  render () {
+    let { packument, spec, json } = this.props
+    let [data] = getData(packument, spec)
+    let views = data.map((pkg) => {
+      const getProps = (field) => ({
+        field,
+        value: resolveField(pkg, field)
+      })
+
+      return <Box>
+        <div>
+          <PackageValue {...getProps('_id')} />
+          <span> | </span>
+          <PackageValue {...getProps('license')} />
+          <span> | </span>
+          <PackageField field='_deps' value={Object.keys(pkg.dependencies || {}).length} />
+          <span> | </span>
+          <span>
+            <span>published </span>
+            <PackageValue field='_time' value={packument.time[pkg.version]} />
+            <span> by </span>
+            <PackageValue {...getProps('_npmUser')} />
+          </span>
+        </div>
+
+        <div>{pkg.description}</div>
+        <span><PackageValue {...getProps('homepage')} /> - <PackageValue {...getProps('keywords')} /></span>
+      </Box>
+    })
+
+    return <Joined
+      delimiter={[<br />, <br />]}>
+      {views}
+    </Joined>
+  }
+}
+module.exports.PackageSummary = PackageSummary
 
 class PackageView extends Component {
   render () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,6 +197,11 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+    },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -1746,6 +1751,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -1835,6 +1841,23 @@
         "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
         "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "eslint-config-standard": {
@@ -2904,6 +2927,23 @@
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "invariant": {
@@ -2928,7 +2968,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -3497,6 +3538,11 @@
         "wrap-ansi": "^3.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
         "wrap-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
@@ -3504,6 +3550,16 @@
           "requires": {
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
           }
         }
       }
@@ -6918,6 +6974,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -6926,6 +6983,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
       "requires": {
         "pinkie-promise": "^2.0.0"
       }
@@ -6973,17 +7031,20 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -7489,12 +7550,23 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
+      "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
       "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
       }
     },
     "slide": {
@@ -7824,6 +7896,21 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -7838,21 +7925,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
       "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g=="
-    },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "requires": {
-        "ansi-regex": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        }
-      }
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -7895,6 +7967,17 @@
         "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        }
       }
     },
     "tacks": {
@@ -8782,6 +8865,11 @@
         "yargs-parser": "^11.1.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
         "cliui": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -8790,6 +8878,16 @@
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0",
             "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
           }
         },
         "cross-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,14 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "requires": {
+        "string-width": "^2.0.0"
+      }
+    },
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -683,6 +691,27 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
       "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
+    "boxen": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "requires": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -897,6 +926,11 @@
       "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
       "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
       "dev": true
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
     },
     "cli-columns": {
       "version": "3.1.2",
@@ -1493,7 +1527,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
       "requires": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
@@ -1713,7 +1746,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -2010,7 +2042,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
       "requires": {
         "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
@@ -2024,8 +2055,7 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         }
       }
     },
@@ -2837,6 +2867,15 @@
         "prop-types": "^15.5.10"
       }
     },
+    "ink-box": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ink-box/-/ink-box-0.1.0.tgz",
+      "integrity": "sha512-JNMn/CygaSnyrUmm1nDEH8u7kFWqf1qA9rHWUbKpW1n1CCsjVF2fRDQSrdiZCj8ZCsinxMB0JgSnvh9xSbyn6w==",
+      "requires": {
+        "boxen": "^1.3.0",
+        "prop-types": "^15.6.1"
+      }
+    },
     "ink-table": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ink-table/-/ink-table-1.0.3.tgz",
@@ -2889,8 +2928,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -6880,7 +6918,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -6889,7 +6926,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
       "requires": {
         "pinkie-promise": "^2.0.0"
       }
@@ -6937,20 +6973,17 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -8007,10 +8040,18 @@
           }
         },
         "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
+      }
+    },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "requires": {
+        "execa": "^0.7.0"
       }
     },
     "text-extensions": {
@@ -8617,6 +8658,14 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "requires": {
+        "string-width": "^2.1.1"
       }
     },
     "window-size": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "graceful-fs": "^4.1.15",
     "ini": "^1.3.5",
     "ink": "^0.5.1",
+    "ink-box": "^0.1.0",
     "ink-table": "^1.0.3",
     "libnpm": "^2.0.1",
     "lock-verify": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "read": "^1.0.7",
     "rimraf": "^2.6.3",
     "semver": "^5.6.0",
+    "slice-ansi": "^2.0.0",
     "spawn-wrap": "^1.4.2",
     "ssri": "^6.0.1",
     "stringify-package": "^1.0.0",


### PR DESCRIPTION
Add a `PackageSummary` for a consistent 3-line information-dense summary of a package. With `Box`:

![screenshot_20181130_211655](https://user-images.githubusercontent.com/14018963/49312712-43fad400-f4e5-11e8-807c-deb510ab7698.png)

Without (not possible currently, I didn't include it due to the way it looks with other content around it):

![screenshot_20181130_211834](https://user-images.githubusercontent.com/14018963/49312778-7efd0780-f4e5-11e8-9633-5da1945706b5.png)

Some TODOs:

  - [x] Description and keywords should be cut off if too long (we don't want extra lines)
  - [x] ~~I think the other thing was "wrap lines if too long", but that's completely contradictory, so scratch that~~

See https://github.com/npm/tink/pull/11#issuecomment-440055235 (@chrisforrette)