### PR TITLE
test: fs pkglock lstatSync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 /test/cache
 yarn.lock
 /lib/commands/utils/.htaccess
+test/.cache
+.vscode

--- a/lib/pkglock.js
+++ b/lib/pkglock.js
@@ -18,13 +18,19 @@ const isPkgLockDisabled = () => !process.tink || process.tink.noPkgLock || envNo
 module.exports.resolve = resolve
 module.exports._clearCache = () => pkgLockCache.clear()
 
+const tinkDir = path.dirname(__dirname)
+
 function resolve (...p) {
   if (isPkgLockDisabled()) { return null }
   const resolved = path.resolve(...p)
-  if (resolved.match(path.dirname(__dirname)) || resolved.match(process.tink.cache)) {
-    // Don't be a smartass about our own sources and cache...
-    return null
+
+  if (!process.tink._isSelf_) {
+    if ((tinkDir && resolved.match(tinkDir)) || (process.tink.cache && resolved.match(process.tink.cache))) {
+      // Don't be a smartass about our own sources and cache...
+      return null
+    }
   }
+
   const result = readPkgLock(resolved)
   if (!result) { return result }
   let { pkgLock, subPath } = result

--- a/test/fixtures/p1/package-lock.json
+++ b/test/fixtures/p1/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "p1",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "require-from-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-path/-/require-from-path-1.0.2.tgz",
+      "integrity": "sha512-hZrak6935a0RVpx6SFJg59IhRuwWkOBX4VPevL8iyxwoT8ep+ILMziLd1f6s5UCeZ6ckEk06xvfAe2I+3IpUaQ=="
+    }
+  }
+}

--- a/test/fixtures/p1/package.json
+++ b/test/fixtures/p1/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "p1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": ""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "require-from-path": "^1.0.0"
+  }
+}

--- a/test/node/fs-pkglock.js
+++ b/test/node/fs-pkglock.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const { test } = require('tap')
+const { overrideNode } = require('../../lib/node/fs')
+
+overrideNode()
+
+test('lstatSync', t => {
+  process.tink = {
+    _isSelf_: true,
+    cache: path.join(__dirname, '../.cache'),
+    config: {
+      concat: () => null
+    }
+  }
+
+  try {
+    const stat = fs.lstatSync(path.join(__dirname, '../fixtures/p1/node_modules/require-from-path/package.json'))
+    t.equal(stat.integrity, 'sha256-zH8eaxFgnwlLNL9Ze8zmBqDB0WbqdOBrSs8r2PO5Jxo=', `fs-pkglock.lstatSync integrity should match`)
+    t.end()
+  } catch (err) {
+    t.fail(`fs-pkglock.lstatSync caught ${err}`)
+  }
+})


### PR DESCRIPTION
- first fs test that uses pkglock
- need to add a `process.tink._isSelf_` to by pass the self check
