### PR TITLE
Remove unused variables

### DIFF
--- a/lib/pkglock.js
+++ b/lib/pkglock.js
@@ -171,9 +171,7 @@ async function read ({ cache, hash, pkg, resolvedPath, isFile }) {
     return ccGet.byDigest(cache, hash, { memoize: true })
   } catch (err) {
     const newResolved = await fetchPackage(cache, pkg, hash)
-    cache = newResolved.cache
-    hash = newResolved.hash
-    pkg = newResolved.pkg
+    const { cache, hash } = newResolved
     return ccGet.byDigest(cache, hash, { memoize: true })
   }
 }
@@ -187,9 +185,7 @@ function readSync ({ cache, hash, pkg, resolvedPath, isFile }) {
     return ccGet.sync.byDigest(cache, hash, { memoize: true })
   } catch (err) {
     const newResolved = fetchPackageSync(cache, pkg, hash)
-    cache = newResolved.cache
-    hash = newResolved.hash
-    pkg = newResolved.pkg
+    const { cache, hash } = newResolved
     return ccGet.sync.byDigest(cache, hash, { memoize: true })
   }
 }
@@ -225,8 +221,6 @@ async function stat ({ cache, hash, pkg, resolvedPath, isDir }, verify) {
     } catch (err) {
       const newResolved = await fetchPackage(cache, pkg, hash)
       cache = newResolved.cache
-      hash = newResolved.hash
-      pkg = newResolved.pkg
       await ssri.checkStream(
         fs.createReadStream.orig(cpath),
         info.sri
@@ -270,8 +264,6 @@ function statSync ({ cache, hash, pkg, resolvedPath, isDir }, verify) {
     } catch (err) {
       const newResolved = fetchPackageSync(cache, pkg, hash)
       cache = newResolved.cache
-      hash = newResolved.hash
-      pkg = newResolved.pkg
       ssri.checkData(
         fs.readFileSync.orig(cpath),
         info.sri


### PR DESCRIPTION
This removes unused variables in the case of `newResolved`