### PR TITLE
[UNFINISHED] Use ts-node to register on-the-fly TS support

### DIFF
--- a/lib/node/extensions.js
+++ b/lib/node/extensions.js
@@ -3,6 +3,13 @@
 module.exports.overrideNode = overrideNode
 
 function overrideNode () {
+  // TODO: Decide which mode to use based on... something? Maybe a combination
+  // of environment variables and command line flags? If you use transpile-only
+  // it will completely skip all type checking and run no matter what.
+  //
+  // require('ts-node/register/transpile-only')
+  require('ts-node/register/type-check')
+
   const fs = require('fs')
   const Module = require('module')
 
@@ -23,16 +30,4 @@ function overrideNode () {
     })
     module._compile(code, filename)
   }
-
-  let tsPlugin
-  Module._extensions['.ts'] = (module, filename) => {
-    const content = fs.readFileSync(filename, 'utf8')
-    if (!babel) { babel = require('babel-core') }
-    if (!tsPlugin) { tsPlugin = require('babel-plugin-transform-typescript') }
-    const { code } = babel.transform(content, {
-      plugins: [tsPlugin]
-    })
-    module._compile(code, filename)
-  }
-  Module._extensions['.tsx'] = Module._extensions['.ts']
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -616,11 +615,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-7.0.0-beta.3.tgz",
       "integrity": "sha512-MH/oJ4i6dm1nqirLIBOiy9T+5gXkouEtHYGot1539jcQTrjDEfX2hgj/cEO9C8LNMMwyr2S95/q6tgfmh4pzlA=="
     },
-    "babel-plugin-syntax-typescript": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-typescript/-/babel-plugin-syntax-typescript-7.0.0-beta.3.tgz",
-      "integrity": "sha512-dHbGBuI13uBlXhEpSFoJeE2NpziLXWJPGvFfVElLyXTSKcphzPN+0ZtpFjBLRyjL4NNCJQznvyvRALyIkXlt9g=="
-    },
     "babel-plugin-transform-react-jsx": {
       "version": "7.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-7.0.0-beta.3.tgz",
@@ -628,14 +622,6 @@
       "requires": {
         "babel-helper-builder-react-jsx": "7.0.0-beta.3",
         "babel-plugin-syntax-jsx": "7.0.0-beta.3"
-      }
-    },
-    "babel-plugin-transform-typescript": {
-      "version": "7.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-typescript/-/babel-plugin-transform-typescript-7.0.0-beta.3.tgz",
-      "integrity": "sha512-5RPAgEhKdYNbopEIhxugUd5x0JqDpMyvJBoXZTXNcLMsMNPfdUOY6AAglNQ7ZaTGeBNHlvPGNFBdoP1GoX2MDg==",
-      "requires": {
-        "babel-plugin-syntax-typescript": "7.0.0-beta.3"
       }
     },
     "balanced-match": {
@@ -3473,8 +3459,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -3502,6 +3487,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
     },
     "make-fetch-happen": {
       "version": "4.0.1",
@@ -4034,7 +4024,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -5217,8 +5206,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -7504,7 +7492,6 @@
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
       "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -7513,8 +7500,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -8089,6 +8075,33 @@
       "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
       "dev": true
     },
+    "ts-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+      "requires": {
+        "arrify": "^1.0.0",
+        "buffer-from": "^1.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^2.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
     "tsame": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/tsame/-/tsame-2.0.1.tgz",
@@ -8128,6 +8141,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -8861,6 +8879,11 @@
           "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
         }
       }
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   "dependencies": {
     "babel-core": "^7.0.0-beta.3",
     "babel-plugin-transform-react-jsx": "^7.0.0-beta.3",
-    "babel-plugin-transform-typescript": "^7.0.0-beta.3",
     "bin-links": "^1.1.2",
     "bluebird": "^3.5.3",
     "byte-size": "^5.0.1",
@@ -113,6 +112,8 @@
     "stringify-package": "^1.0.0",
     "tar": "^4.4.8",
     "tiny-relative-date": "^1.3.0",
+    "ts-node": "^7.0.1",
+    "typescript": "^3.2.4",
     "yargs": "^12.0.5"
   },
   "config": {


### PR DESCRIPTION
This is not done seeing as there's a decision to make about when to enable type checking. Should it use a command line flag? Environment variable? Both? Some kind of complex series of checks to _Do the Right Thing_&trade;?

The core of this change is just adding in `ts-node` since they do a fantastic job of making all this work, and there's no reason to replicate the ~500 lines of code they have.

Note that new tink projects will need to install `@types/node` or `ts-node` and have a simple tsconfig.json if they intend to use JSX" 

```json
{
  "compilerOptions": {
    "jsx": "react"
  }
}
```

There's also still the issue of typescript expecting to traverse node modules to find type definitions, so those will have to be fetched manually for now, I guess?

Also a random note but `tink sh` is giving me a stack overflow on Windows (!).

Another thing, right now it seems that tink shows the usage screen whenever an exception is thrown. This means that type errors are accompanied by like 10 lines of help on screen which are very distracting. Something needs to be done about that for this case, in my opinion.