### PR TITLE
fix(sh): fix node->tish rewrites

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -321,17 +321,17 @@ class Installer {
     if (pkg.scripts) {
       if (pkg.scripts.preinstall) {
         const old = pkg.scripts.preinstall
-        pkg.scripts.preinstall = pkg.scripts.preinstall.replace('node', 'tish')
+        pkg.scripts.preinstall = pkg.scripts.preinstall.replace(/\bnode([^-\w]|$)/, 'tish$1')
         modified = pkg.scripts.preinstall === old
       }
       if (pkg.scripts.install) {
         const old = pkg.scripts.install
-        pkg.scripts.install = pkg.scripts.install.replace('node', 'tish')
+        pkg.scripts.install = pkg.scripts.install.replace(/\bnode([^-\w]|$)/, 'tish$1')
         modified = pkg.scripts.install === old
       }
       if (pkg.scripts.postinstall) {
         const old = pkg.scripts.postinstall
-        pkg.scripts.postinstall = pkg.scripts.postinstall.replace('node', 'tish')
+        pkg.scripts.postinstall = pkg.scripts.postinstall.replace(/\bnode([^-\w]|$)/, 'tish$1')
         modified = pkg.scripts.postinstall === old
       }
       if (modified) {
@@ -391,7 +391,7 @@ class Installer {
     this.log('verbose', 'tinkifyBins', 'convering installed bins to use tink:', bins)
     return BB.map(bins, async bin => {
       const real = await realpathAsync(bin)
-      const data = (await readFileAsync(real, 'utf8')).replace(/(#!\s*.*\s*)node/g, '$1tish')
+      const data = (await readFileAsync(real, 'utf8')).replace(/^(#!.*\b)node([^-\w]|$)/g, '$1tish$2')
       await writeFileAsync(real, data, 'utf8')
     }, { concurrency: 50, Promise: BB })
   }


### PR DESCRIPTION
Make the node->tish rewrites a little less aggresive

Fixes [#5909](https://npm.community/t/tink-trying-to-use-a-package-with-node-gyp-dependencies-results-in-calls-to-tish-gyp-which-fails/5909)