### PR TITLE
fix(pkglock): readPkgLock loop stops

### DIFF
--- a/lib/pkglock.js
+++ b/lib/pkglock.js
@@ -142,7 +142,7 @@ function readPkgLock (resolved) {
   const match = resolved.match(/([/\\]+node_modules)[/\\]?/i)
   let modulesIdx = match && match.index
   let pkgLock
-  while (!pkgLock && modulesIdx >= 0) {
+  while (!pkgLock && modulesIdx) {
     let substr = resolved.substr(0, modulesIdx)
     const pkgLockPath = path.join(substr, pkgLockName)
     if (pkgLockCache.has(pkgLockPath)) {


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->

Hi 👋

I did run tink in a project folder **without** package-lock.json, it resulted in an infinite loop.
After digging around, I found where the problem was (and this is what this PR fixes).

Please read the commit description if you need some context about the modifications.

### Before this PR
1. there is no `package-lock.json` 
2. I run tink
3. tink hang and never responds

```sh
➜  project git:(master) ✗ tink -l silly sh ./src/index.js
tink verb prepare checking package-lock is up to date.



```

### After this PR
1. there is no `package-lock.json` 
2. I run tink
3. tink create a new package-lock.json and try to run `./src/index.js`

```sh
➜  project git:(master) ✗ tink -l silly sh ./src/index.js
tink verb prepare checking package-lock is up to date.
tink verb prepare Fetching and installing dependencies.
tink info prepare initializing installer
tink verb prepare installation prefix: /Volumes/sensitive/work/tink-pnp/demo/project
tink verb checkLock verifying package-lock data
tink verb teardown shutting down
tink info teardown Done in 0.001s
[...]
```

Have a nice weekend,